### PR TITLE
feat : 메타, 데이터 용 2개의 DB 각각 설정

### DIFF
--- a/src/main/java/com/example/samplebatch/config/DataDBConfig.java
+++ b/src/main/java/com/example/samplebatch/config/DataDBConfig.java
@@ -1,0 +1,61 @@
+package com.example.samplebatch.config;
+
+import java.util.HashMap;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+// JPA를 사용할 때 DataSource, LocalContainerEntityManagerFactoryBean, PlatformTransactionManager
+// 추가로 @EnableJpaRepositories 어노테이션 지정 필요
+@EnableJpaRepositories(
+	// 해당 Config가 어떤 패키지에 대해 동작할건지 지정
+	basePackages = "com.example.samplebatch.repository",
+	// 사용할 엔티티매니저, 트랜잭션매니저 메소드명 지정
+	entityManagerFactoryRef = "dataEntityManager",
+	transactionManagerRef = "dataTransactionManager"
+)
+public class DataDBConfig {
+
+	@Bean
+	@ConfigurationProperties(prefix = "spring.datasource-data")
+	public DataSource dataDBSource() {
+		return DataSourceBuilder.create().build();
+	}
+
+	@Bean
+	// 엔티티들을 관리하는 매니저
+	public LocalContainerEntityManagerFactoryBean dataEntityManager() {
+		LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+
+		em.setDataSource(dataDBSource());
+		// 엔티티들이 모여질 패키지들 지정 (해당 경로에 생기는 엔티티는 이 Config가 적용된다)
+		em.setPackagesToScan(new String[] {"com.example.samplebatch.entity"});
+		em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+
+		// 2개의 DB 연결 시 ddl.auto 설정을 Config에서 해줘야 한다.
+		HashMap<String, Object> properties = new HashMap<>();
+		properties.put("hibernate.hbm2ddl.auto", "update");
+		properties.put("hibernate.show_sql", "true");
+		em.setJpaPropertyMap(properties);
+
+		return em;
+	}
+
+	@Bean
+	public PlatformTransactionManager dataTransactionManager() {
+
+		JpaTransactionManager transactionManager = new JpaTransactionManager();
+		transactionManager.setEntityManagerFactory(dataEntityManager().getObject());
+		return transactionManager;
+	}
+}

--- a/src/main/java/com/example/samplebatch/config/MetaDBConfig.java
+++ b/src/main/java/com/example/samplebatch/config/MetaDBConfig.java
@@ -1,0 +1,29 @@
+package com.example.samplebatch.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class MetaDBConfig {
+
+	@Primary // 동일한 Type (Package 경로 + Class명)의 Bean은 1개만 존재해야 하기에 기본값으론 Meta 써라
+	@Bean
+	// properties에 있는 변수 설정 값을 자동으로 불러오는 어노테이션
+	@ConfigurationProperties(prefix = "spring.datasource-meta")
+	public DataSource metaDBSource() {
+		return DataSourceBuilder.create().build();
+	}
+
+	@Primary
+	@Bean
+	public PlatformTransactionManager metaTransactionManager() {
+		return new DataSourceTransactionManager(metaDBSource());
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.batch.job.enabled=false
+
+# ?? DB
+spring.datasource-meta.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource-meta.jdbc-url=jdbc:mysql://localhost:3306/batch_meta?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource-meta.username=root
+spring.datasource-meta.password=
+
+# ?? DB
+spring.datasource-data.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource-data.jdbc-url=jdbc:mysql://localhost:3306/batch_job?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource-data.username=root
+spring.datasource-data.password=


### PR DESCRIPTION
## Multi-DataSource Config 정리

- **MetaDBConfig (JDBC 전용)**  
  - Spring Batch 메타데이터 테이블용  
  - `DataSource` + `DataSourceTransactionManager` 등록  
  - `@Primary` 지정 → Batch 메타테이블 기본 사용  
  - 단순 JDBC만 필요하므로 EntityManager는 불필요  

- **DataDBConfig (JPA 전용)**  
  - 업무 데이터 처리용  
  - `DataSource` + `EntityManagerFactory` + `JpaTransactionManager` 구성  
  - `@EnableJpaRepositories`로 리포지토리 패키지, 팩토리, 트랜잭션 매니저 연결  
  - 서비스에서 필요 시 `@Transactional("dataTransactionManager")` 명시  

### 의도
- **메타데이터는 JDBC, 실제 업무 데이터는 JPA**로 분리  
- Boot 단일 DB 자동구성으로는 해결 불가 → 다중 DB 환경에서는 필수적으로 수동 설정 필요  
- @Primary를 통해 기본 트랜잭션/데이터소스를 명확히 지정, 모호성 제거
